### PR TITLE
Document shared design plan

### DIFF
--- a/DESIGN_PLAN.md
+++ b/DESIGN_PLAN.md
@@ -1,0 +1,87 @@
+# Shared Design Plan
+
+## Goal
+
+Give `sqlfluff.com`, the new VitePress documentation, and the project statistics
+site one coherent visual system. The legacy Sphinx documentation is outside this
+work and will remain unchanged until it is replaced.
+
+## Design ownership
+
+This repository will be the source of truth for the shared design system. An
+internal, repository-local package under `packages/design/` will contain:
+
+- design tokens for colour, typography, spacing, borders, and themes;
+- shared CSS for global chrome and reusable visual components;
+- self-hosted fonts, logos, and icons; and
+- a short contract describing common header, navigation, and footer structure.
+
+The package will not be published to a package registry. Repository commits and
+optional `design-v*` tags will version it.
+
+Framework-specific templates will remain with their applications. The shared
+package should own visual primitives, while Hugo, VitePress, and Observable keep
+small local adapters for their own layouts and behaviour.
+
+## Main site
+
+The main site will remain a Hugo site deployed by Netlify, but will stop using
+Gokarna. Theme-provided layouts and behaviour will be replaced by small,
+project-owned Hugo layouts and partials. These will use the shared package where
+appropriate and keep marketing-only structures in this repository.
+
+Once the replacement is complete, the Gokarna Git submodule and its configuration
+will be removed.
+
+## Documentation and statistics
+
+The SQLFluff and SQLFluff Datacoves repositories will each vendor this repository
+as a Git submodule, for example at `vendor/sqlfluff.com`. Each consumer will:
+
+- pin the submodule to a reviewed commit or `design-v*` tag;
+- initialise only the direct submodule, not nested submodules;
+- import or copy `packages/design/` during its build; and
+- keep its VitePress or Observable adapter in the consuming repository.
+
+Design updates will be explicit pull requests which advance the submodule pointer.
+Each deployed site will bundle the selected design assets, so no site depends on
+`sqlfluff.com` at runtime and historical documentation retains its pinned design.
+
+The existing deployment models remain independent: Hugo on Netlify for the main
+site, VitePress with the versioned R2/Netlify pipeline for documentation, and
+Observable with its data export and Netlify pipeline for statistics.
+
+## Implementation conventions
+
+- Prefix shared custom properties and classes with `--sqlfluff-` and
+  `sqlfluff-` to avoid collisions with framework styles. Application adapters
+  load after the shared CSS and own only framework-specific overrides.
+- Include a small shared theme bootstrap script. It reads a `sqlfluff-theme`
+  cookie with `light`, `dark`, or `auto`, applies the theme to the root element
+  before first paint, and keeps `auto` synchronized with the operating system.
+- On SQLFluff domains, write that preference with `Domain=sqlfluff.com`,
+  `Path=/`, `SameSite=Lax`, `Secure`, and a one-year lifetime so it follows the
+  user between the main, docs, and statistics subdomains. Local and preview
+  environments use a host-only cookie without `Secure` when necessary.
+- Keep global link destinations configurable at build time so beta sites can
+  link to beta peers before cutover. Navigation labels, order, active state,
+  and accessibility semantics should otherwise follow the shared contract.
+- Treat the vendored directory as read-only. A consumer-owned `design:sync`
+  step should validate that the submodule is present and copy only the required
+  assets into that application's generated build directory.
+- Bundle fonts and design assets into each site, use WOFF2 with
+  `font-display: swap`, and make asset paths relative to the consuming site.
+- Preserve visible focus states, skip links, reduced-motion preferences, and
+  semantic landmarks in every local implementation of the shared chrome.
+- Add lightweight visual regression checks at representative mobile and desktop
+  widths in both themes, plus automated accessibility and broken-link checks.
+
+## Delivery order
+
+1. Establish the shared tokens, assets, chrome, and component styles.
+2. Replace Gokarna on `sqlfluff.com` and validate the design there.
+3. Add this repository as a submodule of the VitePress documentation and apply its
+   local adapter.
+4. Add the same submodule to the statistics project and apply its local adapter.
+5. Verify navigation, light and dark themes, accessibility, and responsive layouts
+   across all three sites before the documentation cutover.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 Website for [SQLFluff](http://www.sqlfluff.com/).
 
+The planned migration to a shared visual system for the main site, new
+documentation, and statistics site is described in [DESIGN_PLAN.md](DESIGN_PLAN.md).
+
 * Built with [Hugo](https://gohugo.io/).
 * Using the [Gokarna](https://github.com/gokarna-theme/gokarna-hugo) theme. This
   is installed as a git submodule, so will need updating from time to time.


### PR DESCRIPTION
## Summary

- document the shared visual-system plan for the main site, VitePress docs, and Observable statistics site
- define this repository as the source of the internal design package
- describe Git submodule consumption, theme-cookie behavior, deployment boundaries, and delivery order
- link the plan from the README

## Why

The three future-facing SQLFluff sites need a clear implementation contract before styling work begins. This keeps shared assets and behavior centralized without adding a public package registry or coupling the sites at runtime.

## Impact

This is documentation only. It does not change the current site build or deployment.

## Validation

- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DESIGN_PLAN.md documenting the shared visual system for `sqlfluff.com`, the new VitePress docs, and the Observable stats site, and links it from the README. Defines this repo as the source of the internal `packages/design/` package and outlines Git submodule consumption, `sqlfluff-theme` cookie behavior, deployment boundaries, and rollout order.

<sup>Written for commit 21d200a9b522c59efc8577ae5a6102f66790dfb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff.com/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

