### PR TITLE
Make the shared design package consumable by client-rendered sites

### DIFF
--- a/packages/design/INTEGRATION.md
+++ b/packages/design/INTEGRATION.md
@@ -5,6 +5,23 @@ pinned `sqlfluff.com` Git submodule. It is intentionally framework-neutral: each
 application keeps its own templates and copies the shared static assets into its
 build output.
 
+## Adoption tiers
+
+Not every application can take the whole package. Two tiers are supported, and a
+consumer should state which one it is on:
+
+- **Foundations.** Tokens, typography, fonts, and the theme preference. The
+  application keeps its own header, navigation, and footer, and maps its
+  framework's variables onto the shared ones. This is the right tier for a
+  framework which owns its own chrome, such as VitePress or Observable.
+- **Full chrome.** Foundations plus the shared header, navigation, theme control,
+  and footer markup from section 4. This suits an application which renders its
+  own page shell, such as the Hugo site.
+
+Sections 1 to 3 and 5 to 7 apply to both tiers. Section 4 applies to full chrome,
+and to any foundations-tier consumer which adopts an individual shared component
+such as the theme control.
+
 ## 1. Pin the source
 
 Add this repository at a stable vendor path and commit the resulting gitlink:
@@ -48,8 +65,27 @@ the stylesheets. Load application/framework adapters last:
 <link rel="stylesheet" href="/assets/application-adapter.css">
 ```
 
-Do not add `defer` to `theme.js`: its first pass sets `data-theme` before paint.
-The script defers control and navigation event handlers until the DOM is ready.
+Do not add `defer` to `theme.js`: its first pass applies the theme before paint.
+Control and navigation handlers are delegated from the document, so they are
+registered in the same pass and do not wait for `DOMContentLoaded`.
+
+Because the script is render-blocking, an application which cares about the
+first-paint cost may inline its contents in `head` instead of linking it, as long
+as it still runs before the stylesheets. Read the file from the vendored
+directory at build time rather than copying it into application source.
+
+### Theme signals
+
+`theme.js` sets three things on `<html>`: `data-theme` with the resolved
+`light` or `dark` theme, `data-theme-preference` with the stored `auto`, `light`,
+or `dark` preference, and a `dark` class when the resolved theme is dark. Shared
+tokens respond to either the attribute or the class.
+
+The class exists so a framework whose own styling is keyed on `.dark` — VitePress
+prose, code blocks, and components among them — stays consistent with the shared
+tokens without a per-application shim. An application should let one owner set
+these signals. When the shared script owns them, disable the framework's own
+theme state, for example with VitePress `appearance: false`.
 
 ### Brand assets and metadata
 
@@ -131,8 +167,37 @@ ordering, and temporary visibility are consumer configuration, not package data.
 The script stores `sqlfluff-theme=auto|light|dark`. On `sqlfluff.com` and its
 subdomains it writes `Domain=sqlfluff.com; Path=/; SameSite=Lax; Secure` with a
 one-year lifetime. Other hosts receive a host-only cookie, with `Secure` on HTTPS.
-It sets `data-theme` and `data-theme-preference` on `<html>` and follows operating
-system changes while the preference is `auto`.
+It follows operating system changes while the preference is `auto`.
+
+A cookie is used rather than `localStorage` because it is the only channel which
+is both readable before first paint and shared between the SQLFluff subdomains;
+`localStorage` is origin-scoped, and the hidden-iframe workaround is asynchronous
+and is partitioned by current browsers. A same-origin `localStorage` copy is kept
+only as a fallback for readers whose browser rejects cookies.
+
+The cookie name and its `auto`, `light`, and `dark` vocabulary are a frozen
+compatibility contract. Consumers which publish immutable versioned builds, such
+as the documentation archive, bundle the copy of `theme.js` they were built with,
+so old builds must keep interoperating with current ones indefinitely.
+
+### Driving the theme from an application
+
+`theme.js` exposes `window.sqlfluffTheme` for applications which render their own
+control or need to mirror the state into framework code:
+
+```js
+window.sqlfluffTheme.get()        // 'auto' | 'light' | 'dark'
+window.sqlfluffTheme.resolved()   // 'light' | 'dark'
+window.sqlfluffTheme.set('dark')  // store, apply, and notify
+window.sqlfluffTheme.sync()       // refresh aria-pressed on rendered controls
+window.sqlfluffTheme.subscribe(fn) // call now and on change; returns unsubscribe
+```
+
+Client-rendered applications do not need this to make the documented markup work.
+Clicks are delegated from the document, so a control which is mounted, replaced,
+or unmounted after load behaves the same as server-rendered markup. What is not
+automatic is `aria-pressed` on controls created after the last theme change: bind
+it from `subscribe`, or call `sync` after rendering.
 
 ### Buttons and social links
 
@@ -245,7 +310,10 @@ own schedule.
 
 - The three CSS files, theme script, fonts, wordmark, and referenced icons return
   `200` from the deployed origin.
-- Light, dark, and automatic preferences work before and after navigation.
+- Light, dark, and automatic preferences work before and after navigation,
+  including after a client-side route change in a rendered application.
+- Only one owner sets the theme signals, and the framework's own theme state is
+  disabled where the shared script owns them.
 - The preference follows the user between production SQLFluff subdomains.
 - The active navigation link is correct and the mobile menu opens, closes, and
   responds to Escape.

--- a/packages/design/INTEGRATION.md
+++ b/packages/design/INTEGRATION.md
@@ -149,6 +149,14 @@ the following stable classes and data attributes.
 Set `aria-current="page"` only on the active destination. Labels, destinations,
 ordering, and temporary visibility are consumer configuration, not package data.
 
+The header separator is scroll-aware. `theme.js` adds `is-top` to each
+`[data-sqlfluff-nav]` element while the page is scrolled to the top, and the
+stylesheet clears the bottom border while that class is present, so the line
+only appears once content is passing under the header. The border is the
+default state, so a reader without JavaScript keeps a separated header. A
+consumer whose framework already does this, such as VitePress, should keep its
+own implementation rather than adding a second one.
+
 ### Theme control
 
 ```html

--- a/packages/design/INTEGRATION.md
+++ b/packages/design/INTEGRATION.md
@@ -205,15 +205,21 @@ control or need to mirror the state into framework code:
 window.sqlfluffTheme.get()        // 'auto' | 'light' | 'dark'
 window.sqlfluffTheme.resolved()   // 'light' | 'dark'
 window.sqlfluffTheme.set('dark')  // store, apply, and notify
-window.sqlfluffTheme.sync()       // refresh aria-pressed on rendered controls
+window.sqlfluffTheme.sync()       // resynchronise chrome after rendering it
 window.sqlfluffTheme.subscribe(fn) // call now and on change; returns unsubscribe
 ```
 
 Client-rendered applications do not need this to make the documented markup work.
 Clicks are delegated from the document, so a control which is mounted, replaced,
-or unmounted after load behaves the same as server-rendered markup. What is not
-automatic is `aria-pressed` on controls created after the last theme change: bind
-it from `subscribe`, or call `sync` after rendering.
+or unmounted after load behaves the same as server-rendered markup.
+
+What is not automatic is state which is only recalculated when something changes:
+`aria-pressed` on controls created after the last theme change, and the
+scroll-aware `is-top` class on a header mounted since the last scroll. Call
+`sync` after rendering shared chrome, or bind `aria-pressed` from `subscribe`.
+An application which renders the shared header on every route change should call
+`sync` from that lifecycle, otherwise the header will show its separator at the
+top of the page until the reader first scrolls.
 
 ### Buttons and social links
 

--- a/packages/design/INTEGRATION.md
+++ b/packages/design/INTEGRATION.md
@@ -65,6 +65,14 @@ the stylesheets. Load application/framework adapters last:
 <link rel="stylesheet" href="/assets/application-adapter.css">
 ```
 
+The element-level rules in `base.css` sit in a `sqlfluff-base` cascade layer, so
+they are a floor rather than a ceiling: a framework which styles the same bare
+elements keeps winning no matter which file loads last. Tokens, shared component
+classes, and the utility classes are unlayered and behave normally. An adapter
+therefore does not need to reproduce framework typography to defend it, and does
+not need the shared stylesheets to load in any particular position relative to
+the framework's own bundle.
+
 Do not add `defer` to `theme.js`: its first pass applies the theme before paint.
 Control and navigation handlers are delegated from the document, so they are
 registered in the same pass and do not wait for `DOMContentLoaded`.

--- a/packages/design/README.md
+++ b/packages/design/README.md
@@ -13,7 +13,8 @@ through a pinned Git submodule.
 - `static/sqlfluff-design/css/components.css`: shared container, header,
   navigation, theme switcher, buttons, social links, terminal, and footer.
 - `static/sqlfluff-design/js/theme.js`: theme preference and responsive navigation
-  behaviour.
+  behaviour, delegated from the document so it also serves client-rendered
+  applications, and exposing `window.sqlfluffTheme` for framework adapters.
 - `static/sqlfluff-design/img/`: wordmarks, social image, favicons, and application
   icons.
 - `static/sqlfluff-design/icons/`: shared interface and social icons.

--- a/packages/design/static/sqlfluff-design/css/base.css
+++ b/packages/design/static/sqlfluff-design/css/base.css
@@ -30,6 +30,19 @@
   font-display: swap;
 }
 
+/*
+ * Element-level foundations are layered so they act as a floor rather than a
+ * ceiling. Unlayered CSS always wins over layered CSS regardless of source
+ * order, which lets an application whose framework styles the same bare
+ * elements load this file in whatever order suits it without the shared reset
+ * overriding the framework's own typography and surfaces.
+ *
+ * Shared utility classes and the reduced-motion guard stay outside the layer:
+ * a consumer opts into those by name and they must not be overridden by
+ * accident.
+ */
+@layer sqlfluff-base {
+
 *,
 *::before,
 *::after {
@@ -135,6 +148,8 @@ select {
   cursor: pointer;
 }
 
+}
+
 .sqlfluff-visually-hidden {
   position: absolute;
   width: 1px;
@@ -164,6 +179,8 @@ select {
   transform: translateY(0);
 }
 
+@layer sqlfluff-base {
+
 @media (max-width: 720px) {
   h1 {
     font-size: 2.5rem;
@@ -172,6 +189,8 @@ select {
   h2 {
     font-size: 1.5rem;
   }
+}
+
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/packages/design/static/sqlfluff-design/css/components.css
+++ b/packages/design/static/sqlfluff-design/css/components.css
@@ -11,6 +11,17 @@
   background: color-mix(in srgb, var(--sqlfluff-color-canvas) 94%, transparent);
   border-bottom: 1px solid var(--sqlfluff-color-border);
   backdrop-filter: blur(12px);
+  transition: border-bottom-color 0.25s;
+}
+
+/*
+ * `theme.js` adds this at the top of the page, so the separator only appears
+ * once content is passing under the header. The colour is cleared rather than
+ * the border removed, so the header does not shift by a pixel as it toggles,
+ * and the background and blur stay constant either way.
+ */
+.sqlfluff-site-header.is-top {
+  border-bottom-color: transparent;
 }
 
 .sqlfluff-header-inner {

--- a/packages/design/static/sqlfluff-design/css/tokens.css
+++ b/packages/design/static/sqlfluff-design/css/tokens.css
@@ -32,7 +32,11 @@
   --sqlfluff-shadow-sm: 0 1px 2px rgb(29 37 43 / 8%);
 }
 
-:root[data-theme="dark"] {
+/* `theme.js` sets both signals. The class is also accepted so an application
+   whose framework already owns a `dark` class can adopt these tokens without
+   running the shared script. */
+:root[data-theme="dark"],
+:root.dark {
   color-scheme: dark;
   --sqlfluff-color-canvas: #0d1117;
   --sqlfluff-color-surface: #161b22;

--- a/packages/design/static/sqlfluff-design/js/theme.js
+++ b/packages/design/static/sqlfluff-design/js/theme.js
@@ -68,7 +68,9 @@
 
     syncControls(preference);
 
-    subscribers.forEach(function (listener) {
+    // Iterate a snapshot: a listener which unsubscribes itself while handling
+    // the change would otherwise shift the live array and skip its neighbour.
+    subscribers.slice().forEach(function (listener) {
       try {
         listener(preference, theme);
       } catch (error) {
@@ -210,10 +212,13 @@
     },
     /** Store a preference and apply it. Invalid values fall back to `auto`. */
     set: writePreference,
-    /** Refresh `aria-pressed` after an application renders its own controls. */
-    sync: function () {
-      syncControls(readPreference());
-    },
+    /**
+     * Resynchronise shared chrome after an application mounts or replaces its
+     * own markup: `aria-pressed` on theme controls, and the scroll-aware state
+     * of any header. Without this a header mounted at the top of the page
+     * would show its separator until the reader first scrolls.
+     */
+    sync: syncRenderedChrome,
     /**
      * Observe preference changes. The listener is called immediately with the
      * current state, then on every change. Returns an unsubscribe function.

--- a/packages/design/static/sqlfluff-design/js/theme.js
+++ b/packages/design/static/sqlfluff-design/js/theme.js
@@ -3,15 +3,36 @@
 
   var COOKIE_NAME = "sqlfluff-theme";
   var VALID_PREFERENCES = ["auto", "light", "dark"];
+  var DARK_CLASS = "dark";
+  var THEME_COLOURS = { light: "#f7f8f8", dark: "#0d1117" };
   var mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+  var subscribers = [];
 
-  function readPreference() {
+  function normalise(value) {
+    return VALID_PREFERENCES.indexOf(value) >= 0 ? value : "auto";
+  }
+
+  function readCookie() {
     var prefix = COOKIE_NAME + "=";
     var cookie = document.cookie.split("; ").find(function (item) {
       return item.indexOf(prefix) === 0;
     });
-    var value = cookie ? decodeURIComponent(cookie.slice(prefix.length)) : "auto";
-    return VALID_PREFERENCES.indexOf(value) >= 0 ? value : "auto";
+    return cookie ? decodeURIComponent(cookie.slice(prefix.length)) : "";
+  }
+
+  // Same-origin fallback for readers whose browser or privacy settings reject
+  // cookies. It cannot follow a reader between subdomains, so the cookie stays
+  // the primary record and this is only consulted when the cookie is absent.
+  function readFallback() {
+    try {
+      return window.localStorage.getItem(COOKIE_NAME) || "";
+    } catch (error) {
+      return "";
+    }
+  }
+
+  function readPreference() {
+    return normalise(readCookie() || readFallback());
   }
 
   function resolveTheme(preference) {
@@ -21,22 +42,43 @@
     return preference;
   }
 
-  function applyPreference(preference) {
-    var theme = resolveTheme(preference);
-    var themeColour = document.querySelector('meta[name="theme-color"]');
-    document.documentElement.dataset.themePreference = preference;
-    document.documentElement.dataset.theme = theme;
-    document.documentElement.style.colorScheme = theme;
-    if (themeColour) {
-      themeColour.setAttribute("content", theme === "dark" ? "#0d1117" : "#f7f8f8");
-    }
-
+  function syncControls(preference) {
     document.querySelectorAll("[data-sqlfluff-theme-value]").forEach(function (button) {
       button.setAttribute("aria-pressed", String(button.dataset.sqlfluffThemeValue === preference));
     });
   }
 
-  function writePreference(preference) {
+  function applyPreference(preference) {
+    var root = document.documentElement;
+    var theme = resolveTheme(preference);
+    var themeColour = document.querySelector('meta[name="theme-color"]');
+
+    root.dataset.themePreference = preference;
+    root.dataset.theme = theme;
+    root.style.colorScheme = theme;
+
+    // Frameworks with their own dark styling, such as VitePress, key off a
+    // `dark` class rather than an attribute. Setting both lets a consumer adopt
+    // the shared tokens without shimming one signal onto the other.
+    root.classList.toggle(DARK_CLASS, theme === "dark");
+
+    if (themeColour) {
+      themeColour.setAttribute("content", THEME_COLOURS[theme]);
+    }
+
+    syncControls(preference);
+
+    subscribers.forEach(function (listener) {
+      try {
+        listener(preference, theme);
+      } catch (error) {
+        // A failing subscriber must not stop the others or the theme swap.
+      }
+    });
+  }
+
+  function writePreference(value) {
+    var preference = normalise(value);
     var hostname = window.location.hostname;
     var isSqlfluffDomain = hostname === "sqlfluff.com" || hostname.endsWith(".sqlfluff.com");
     var parts = [
@@ -53,59 +95,111 @@
     }
 
     document.cookie = parts.join("; ");
+
+    try {
+      window.localStorage.setItem(COOKIE_NAME, preference);
+    } catch (error) {
+      // Storage is optional; the cookie above is the primary record.
+    }
+
     applyPreference(preference);
   }
 
-  function initialiseControls() {
-    applyPreference(readPreference());
+  function setMenuState(header, isOpen) {
+    var toggle = header.querySelector("[data-sqlfluff-nav-toggle]");
+    var menu = header.querySelector("[data-sqlfluff-nav-menu]");
+    if (!toggle || !menu) return;
+    var label = toggle.querySelector(".sqlfluff-visually-hidden");
 
-    document.querySelectorAll("[data-sqlfluff-theme-value]").forEach(function (button) {
-      button.addEventListener("click", function () {
-        writePreference(button.dataset.sqlfluffThemeValue);
-      });
-    });
+    menu.classList.toggle("is-open", isOpen);
+    toggle.setAttribute("aria-expanded", String(isOpen));
+    if (label) label.textContent = isOpen ? "Close navigation" : "Open navigation";
+  }
 
+  function closeMenus() {
     document.querySelectorAll("[data-sqlfluff-nav]").forEach(function (header) {
-      var toggle = header.querySelector("[data-sqlfluff-nav-toggle]");
-      var menu = header.querySelector("[data-sqlfluff-nav-menu]");
-      if (!toggle || !menu) return;
-      var toggleLabel = toggle.querySelector(".sqlfluff-visually-hidden");
-
-      function setMenuState(isOpen) {
-        menu.classList.toggle("is-open", isOpen);
-        toggle.setAttribute("aria-expanded", String(isOpen));
-        if (toggleLabel) toggleLabel.textContent = isOpen ? "Close navigation" : "Open navigation";
-      }
-
-      function closeMenu() {
-        setMenuState(false);
-      }
-
-      toggle.addEventListener("click", function () {
-        setMenuState(!menu.classList.contains("is-open"));
-      });
-
-      menu.querySelectorAll("a").forEach(function (link) {
-        link.addEventListener("click", closeMenu);
-      });
-
-      document.addEventListener("keydown", function (event) {
-        if (event.key === "Escape" && menu.classList.contains("is-open")) {
-          closeMenu();
-          toggle.focus();
-        }
-      });
+      setMenuState(header, false);
     });
   }
 
+  // Delegated from the document so the contract also holds for controls which
+  // a client-rendered application mounts, replaces, or unmounts after load.
+  document.addEventListener("click", function (event) {
+    var target = event.target;
+    if (!target || typeof target.closest !== "function") return;
+
+    var themeButton = target.closest("[data-sqlfluff-theme-value]");
+    if (themeButton) {
+      writePreference(themeButton.dataset.sqlfluffThemeValue);
+      return;
+    }
+
+    var toggle = target.closest("[data-sqlfluff-nav-toggle]");
+    if (toggle) {
+      var header = toggle.closest("[data-sqlfluff-nav]");
+      if (!header) return;
+      var menu = header.querySelector("[data-sqlfluff-nav-menu]");
+      setMenuState(header, !(menu && menu.classList.contains("is-open")));
+      return;
+    }
+
+    if (target.closest("[data-sqlfluff-nav-menu] a")) {
+      closeMenus();
+    }
+  });
+
+  document.addEventListener("keydown", function (event) {
+    if (event.key !== "Escape") return;
+
+    var open = document.querySelector("[data-sqlfluff-nav-menu].is-open");
+    if (!open) return;
+
+    var header = open.closest("[data-sqlfluff-nav]");
+    var toggle = header && header.querySelector("[data-sqlfluff-nav-toggle]");
+    closeMenus();
+    if (toggle) toggle.focus();
+  });
+
   applyPreference(readPreference());
+
   mediaQuery.addEventListener("change", function () {
     if (readPreference() === "auto") applyPreference("auto");
   });
 
+  // Server-rendered controls are not in the document while this runs in `head`.
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", initialiseControls);
-  } else {
-    initialiseControls();
+    document.addEventListener("DOMContentLoaded", function () {
+      syncControls(readPreference());
+    });
   }
+
+  window.sqlfluffTheme = {
+    /** Current preference: `auto`, `light`, or `dark`. */
+    get: function () {
+      return readPreference();
+    },
+    /** Theme the current preference resolves to: `light` or `dark`. */
+    resolved: function () {
+      return resolveTheme(readPreference());
+    },
+    /** Store a preference and apply it. Invalid values fall back to `auto`. */
+    set: writePreference,
+    /** Refresh `aria-pressed` after an application renders its own controls. */
+    sync: function () {
+      syncControls(readPreference());
+    },
+    /**
+     * Observe preference changes. The listener is called immediately with the
+     * current state, then on every change. Returns an unsubscribe function.
+     */
+    subscribe: function (listener) {
+      subscribers.push(listener);
+      listener(readPreference(), resolveTheme(readPreference()));
+
+      return function () {
+        var index = subscribers.indexOf(listener);
+        if (index >= 0) subscribers.splice(index, 1);
+      };
+    }
+  };
 })();

--- a/packages/design/static/sqlfluff-design/js/theme.js
+++ b/packages/design/static/sqlfluff-design/js/theme.js
@@ -105,6 +105,25 @@
     applyPreference(preference);
   }
 
+  // The header separator is only drawn once content has scrolled under it. The
+  // border is present by default and this removes it at the top of the page, so
+  // a reader without JavaScript keeps a separated header rather than none.
+  var scrollFrame = 0;
+
+  function syncHeaderScroll() {
+    scrollFrame = 0;
+    var isTop = (window.scrollY || window.pageYOffset || 0) <= 0;
+
+    document.querySelectorAll("[data-sqlfluff-nav]").forEach(function (header) {
+      header.classList.toggle("is-top", isTop);
+    });
+  }
+
+  function queueHeaderScroll() {
+    if (scrollFrame) return;
+    scrollFrame = window.requestAnimationFrame(syncHeaderScroll);
+  }
+
   function setMenuState(header, isOpen) {
     var toggle = header.querySelector("[data-sqlfluff-nav-toggle]");
     var menu = header.querySelector("[data-sqlfluff-nav-menu]");
@@ -166,11 +185,18 @@
     if (readPreference() === "auto") applyPreference("auto");
   });
 
-  // Server-rendered controls are not in the document while this runs in `head`.
+  window.addEventListener("scroll", queueHeaderScroll, { passive: true });
+
+  // Server-rendered chrome is not in the document while this runs in `head`.
+  function syncRenderedChrome() {
+    syncControls(readPreference());
+    syncHeaderScroll();
+  }
+
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", function () {
-      syncControls(readPreference());
-    });
+    document.addEventListener("DOMContentLoaded", syncRenderedChrome);
+  } else {
+    syncRenderedChrome();
   }
 
   window.sqlfluffTheme = {


### PR DESCRIPTION
## Summary

Stacked on #18. Base is `create-shared-design-library`, not `main`, so the diff here is only the four commits below — targeting `main` would replay all of #18.

These changes came out of actually vendoring the package into the SQLFluff VitePress docs. Each one is a problem that integration hit, fixed here rather than worked around in the consumer.

- **Delegate theme and navigation handlers from the document.** They were bound once at `DOMContentLoaded` with `querySelectorAll`. That suits server-rendered markup, but a client-rendered consumer mounts its chrome after that point and recreates it across route changes, so the documented markup would have rendered correctly and then done nothing.
- **Set a `dark` class alongside `data-theme`, and accept either in `tokens.css`.** Frameworks with their own dark styling key off a class rather than an attribute. Emitting both lets a consumer adopt the tokens without maintaining a shim between the two signals.
- **Add `window.sqlfluffTheme`** (`get`/`resolved`/`set`/`sync`/`subscribe`) so an application can drive and observe the preference without reimplementing cookie parsing, plus a same-origin `localStorage` fallback for readers whose browser rejects cookies. The cookie stays the primary record — it is the only channel both readable before first paint and shared across the subdomains.
- **Put `base.css` element rules in a `sqlfluff-base` cascade layer.** They were unlayered, so whichever stylesheet loaded last won. In VitePress the shared sheets are linked from `head` while the framework bundle is emitted earlier, so shared `body { background: canvas }` overrode the framework's reading surface. Unlayered CSS always beats layered CSS regardless of order, which makes the foundations a floor rather than a ceiling.
- **Draw the header separator only once content scrolls under it.** The border was permanent, reading as fixed furniture rather than a response to the page.
- **Document adoption tiers.** The header, navigation, and footer contract assumes a consumer which renders its own page shell. A framework that owns its chrome cannot take it, so the guide now names a foundations tier and a full chrome tier and says which sections apply to each. Also documents the theme signals, the API, why a cookie rather than `localStorage`, and freezes the cookie name and `auto|light|dark` vocabulary as a compatibility contract, since consumers publishing immutable versioned builds bundle the copy of `theme.js` they were built with.

## What actually changes on sqlfluff.com

Only one thing is visible: **the header bottom border now appears when you scroll and is absent at the top of the page.** The colour is cleared rather than the border removed, so nothing shifts by a pixel as it toggles, and the background and blur stay constant so only the line animates.

Everything else is enabling work for consumers and should be a visual no-op here. The cascade layer in particular is deliberately inert on this site: `site.css` already loaded last and won, so layering changes nothing it was already winning.

## Review focus

- The scroll behaviour on the header, in both themes and at mobile widths.
- That the layer change really is a no-op — worth a side-by-side against the #18 preview.
- Whether the border should stay clear at the top on interior pages as well as the homepage, which is what this does. VitePress instead keeps the divider on pages with a sidebar.

## Validation

- Hugo builds clean; static assets, including the layer syntax, survive `--minify` verbatim.
- `theme.js` behaviour covered by a jsdom harness, 22 assertions passing: pre-paint application, a control mounted after load, a control replaced after a route change, subscribe/unsubscribe, invalid input, nav toggle including Escape and link-dismiss, and the scroll toggle.
- Verified end to end by vendoring this branch into the SQLFluff docs and building the VitePress site against it.

## Note on merge

Consumers pin this by exact commit. If this and #18 are squash-merged with the branches deleted, those commits become unreachable and the SQLFluff docs pin breaks. Either keep the branches until consumers re-pin, or tag the merged result as `design-v*`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the shared design package work in client‑rendered sites by delegating handlers, adding a simple theme API, and layering base styles. On sqlfluff.com, the only visible change is the header divider appears after you scroll.

- **New Features**
  - Delegate theme switcher and navigation from the document so controls work after mount and across route changes.
  - Expose `window.sqlfluffTheme` (`get`, `resolved`, `set`, `sync`, `subscribe`) with a cookie-backed preference and same-origin `localStorage` fallback; also updates `meta[name="theme-color"]`.
  - Set a `.dark` class alongside `data-theme`; tokens respond to either.
  - Show the header separator only once content scrolls under it.

- **Bug Fixes**
  - Iterate a snapshot of subscribers so an unsubscribing listener does not skip its neighbour.
  - `sqlfluffTheme.sync()` now resynchronizes header scroll state as well as control `aria-pressed`, so a freshly mounted header renders correctly at the top of the page.

<sup>Written for commit 55f888ac37bb381643b53a529ddade368722f27c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff.com/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

