### PR TITLE
Proxy /stats to the statistics site

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -10,7 +10,7 @@ disableKinds = ['taxonomy', 'term']
 [params]
   description = "The SQL linter for humans"
   metaKeywords = ["sqlfluff", "sql", "linter"]
-  showStats = false # Enable when the statistics site is ready for general use.
+  showStats = true
   socialIcons = [
     {name = "github", label = "GitHub", url = "https://github.com/sqlfluff"},
     {name = "docker", label = "Docker Hub", url = "https://hub.docker.com/r/sqlfluff/sqlfluff"},
@@ -24,5 +24,5 @@ disableKinds = ['taxonomy', 'term']
 
   [params.links]
     docs = "https://docs.sqlfluff.com"
-    stats = "https://stats.beta.sqlfluff.com"
+    stats = "/stats/"
     source = "https://github.com/sqlfluff/sqlfluff"

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,13 +11,13 @@
   TZ = "Europe/London"
 
 [[redirects]]
-  from = "/stats"
-  to = "/stats/"
-  status = 301
-  force = true
-
-[[redirects]]
   from = "/stats/*"
   to = "https://brilliant-naiad-526a97.netlify.app/:splat"
   status = 200
+  force = true
+
+[[redirects]]
+  from = "/stats"
+  to = "/stats/"
+  status = 301
   force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,9 +15,3 @@
   to = "https://brilliant-naiad-526a97.netlify.app/:splat"
   status = 200
   force = true
-
-[[redirects]]
-  from = "/stats"
-  to = "/stats/"
-  status = 301
-  force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,4 +9,15 @@
 [build.environment]
   HUGO_VERSION = "0.125.4"
   TZ = "Europe/London"
-  
+
+[[redirects]]
+  from = "/stats"
+  to = "/stats/"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/stats/*"
+  to = "https://brilliant-naiad-526a97.netlify.app/:splat"
+  status = 200
+  force = true


### PR DESCRIPTION
## Summary
- Adds two Netlify redirect rules so `sqlfluff.com/stats` transparently proxies (status 200) to the statistics site's Netlify deploy at `https://brilliant-naiad-526a97.netlify.app`, with a 301 from the bare `/stats` to the trailing-slash form (needed because the stats site's build emits relative asset paths that depend on being served from a directory-style URL).
- Re-enables the existing `showStats` nav/footer link (previously disabled with `showStats = false`) and repoints `params.links.stats` from the old `stats.beta.sqlfluff.com` subdomain to the same-origin `/stats/` path.

This keeps the statistics site's own repo, build, and deploy cadence fully independent — this PR only adds edge-level routing so it appears under the main domain.

## Test plan
- [x] Built the Hugo site locally (`hugo --gc --minify`) and confirmed the header/footer render `<a href=/stats/>Stats</a>` and `<a href=/stats/>Project statistics</a>`.
- [x] Built the stats site locally and inspected its generated `dist/index.html`: all Framework-internal asset/data references are relative (`./...`), so they resolve correctly once served under `/stats/`; the only root-absolute references are to `/sqlfluff-design/*`, which this repo already serves natively from `packages/design/static/sqlfluff-design`.
- [ ] After merge/deploy, verify `sqlfluff.com/stats` and `sqlfluff.com/stats/` both load the statistics site correctly in production, and that the nav link works from the homepage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proxies sqlfluff.com/stats to the statistics site's Netlify app and enables the Stats link, so the stats site appears under the main domain. Removes the redundant exact /stats redirect to avoid precedence issues and redirect loops.

- **New Features**
  - Proxy /stats/* → https://brilliant-naiad-526a97.netlify.app/:splat (200, force).
  - Enable showStats and point params.links.stats to /stats/.

- **Bug Fixes**
  - Removed the exact /stats redirect; Netlify normalizes slashes so it overlapped with the wildcard and caused loops. The wildcard alone handles bare /stats (200), and the stats app adds the trailing slash client-side.

<sup>Written for commit 01ea410fde6395964ab393124712e7af1083508b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff.com/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

