### PR TITLE
Make the design package consumable as a pinned Git dependency

### DIFF
--- a/DESIGN_PLAN.md
+++ b/DESIGN_PLAN.md
@@ -32,15 +32,18 @@ and styles in this repository.
 
 ## Documentation and statistics
 
-The SQLFluff and SQLFluff Datacoves repositories will each vendor this repository
-as a Git submodule, for example at `vendor/sqlfluff.com`. Each consumer will:
+The SQLFluff and SQLFluff Datacoves repositories will each depend on this
+repository from Git, pinned to a reviewed commit. Each consumer will:
 
-- pin the submodule to a reviewed commit or `design-v*` tag;
-- initialise only the direct submodule, not nested submodules;
-- import or copy `packages/design/` during its build; and
+- declare `@sqlfluff/design` as a Git dependency on a reviewed commit or
+  `design-v*` tag, using the `&path:/packages/design` subdirectory suffix;
+- copy the package's assets into its own build output during the build; and
 - keep its VitePress or Observable adapter in the consuming repository.
 
-Design updates will be explicit pull requests which advance the submodule pointer.
+A Git submodule remains a fallback for any consumer without a Node toolchain,
+reading the same directory.
+
+Design updates will be explicit pull requests which advance the pinned commit.
 Each deployed site will bundle the selected design assets, so no site depends on
 `sqlfluff.com` at runtime and historical documentation retains its pinned design.
 
@@ -63,8 +66,8 @@ Observable with its data export and Netlify pipeline for statistics.
 - Keep global link destinations configurable at build time so beta sites can
   link to beta peers before cutover. Navigation labels, order, active state,
   and accessibility semantics should otherwise follow the shared contract.
-- Treat the vendored directory as read-only. A consumer-owned `design:sync`
-  step should validate that the submodule is present and copy only the required
+- Treat the installed package as read-only. A consumer-owned `design:sync`
+  step should validate that the package is present and copy only the required
   assets into that application's generated build directory.
 - Bundle fonts and design assets into each site, use WOFF2 with
   `font-display: swap`, and make asset paths relative to the consuming site.
@@ -77,8 +80,8 @@ Observable with its data export and Netlify pipeline for statistics.
 
 1. Establish the shared tokens, assets, chrome, and component styles.
 2. Replace Gokarna on `sqlfluff.com` and validate the design there.
-3. Add this repository as a submodule of the VitePress documentation and apply its
-   local adapter.
-4. Add the same submodule to the statistics project and apply its local adapter.
+3. Depend on this package from the VitePress documentation and apply its local
+   adapter.
+4. Add the same dependency to the statistics project and apply its local adapter.
 5. Verify navigation, light and dark themes, accessibility, and responsive layouts
    across all three sites before the documentation cutover.

--- a/packages/design/INTEGRATION.md
+++ b/packages/design/INTEGRATION.md
@@ -1,7 +1,7 @@
 # Consumer integration
 
-This guide is the implementation contract for consuming SQLFluff Design from a
-pinned `sqlfluff.com` Git submodule. It is intentionally framework-neutral: each
+This guide is the implementation contract for consuming SQLFluff Design as a
+pinned dependency on this repository. It is intentionally framework-neutral: each
 application keeps its own templates and copies the shared static assets into its
 build output.
 
@@ -24,32 +24,64 @@ such as the theme control.
 
 ## 1. Pin the source
 
-Add this repository at a stable vendor path and commit the resulting gitlink:
+The package is not published to a registry. A consumer with a Node toolchain
+depends on it directly from Git, pinned to a reviewed commit:
 
-```sh
-git submodule add https://github.com/sqlfluff/sqlfluff.com.git vendor/sqlfluff.com
-git submodule update --init vendor/sqlfluff.com
+```jsonc
+// package.json
+"devDependencies": {
+  "@sqlfluff/design": "github:sqlfluff/sqlfluff.com#<commit>&path:/packages/design"
+}
 ```
 
-CI should fail clearly when the submodule is absent. Do not initialise unrelated
-or nested submodules.
+The `&path:` suffix is required. This repository is a Hugo site with no root
+`package.json`, so the package lives in a subdirectory; without the suffix the
+whole site is installed as an unnamed package.
+
+That syntax is understood by **pnpm 9 and later**. npm and Yarn do not support
+subdirectories in Git dependencies and will fail looking for a `package.json` at
+the repository root, so a consumer using this route should require pnpm, for
+example with `"engines": { "pnpm": ">=9" }`.
+
+The lockfile records the resolved commit and, on a cold store, an integrity hash.
+Advance the pin in an ordinary pull request so the change is reviewed. Note that
+a commit reachable only from a branch which is later squash-merged and deleted
+becomes unreachable, which breaks the pin; prefer pinning commits on `main`.
+
+A consumer without a Node toolchain can instead vendor this repository as a Git
+submodule and read the same `packages/design/static/sqlfluff-design` directory.
+The rest of this guide applies unchanged either way.
 
 ## 2. Copy the assets
 
-Copy only the package's public directory into the consumer's static/public output.
+Copy only the package's asset directory into the consumer's static/public output.
 For a project whose static directory is `public/`:
 
 ```sh
-test -d vendor/sqlfluff.com/packages/design/static/sqlfluff-design
 rsync -a --delete \
-  vendor/sqlfluff.com/packages/design/static/sqlfluff-design/ \
+  node_modules/@sqlfluff/design/static/sqlfluff-design/ \
   public/sqlfluff-design/
 ```
 
+Resolve the package through its manifest rather than assuming that path, so the
+step survives a hoisted, symlinked, or otherwise relocated store:
+
+```js
+import { createRequire } from 'node:module'
+import { dirname, resolve } from 'node:path'
+
+const manifest = createRequire(import.meta.url).resolve('@sqlfluff/design/package.json')
+const assets = resolve(dirname(manifest), 'static/sqlfluff-design')
+```
+
 Run this as the consumer's `design:sync` step before local development and before
-the production build. The deployed assets must be available at
-`/sqlfluff-design/`; no application should fetch them from another SQLFluff site
-at runtime.
+the production build, and fail with actionable guidance when the package is
+missing. The deployed assets must be available at `/sqlfluff-design/`; no
+application should fetch them from another SQLFluff site at runtime.
+
+The package's `exports` map exposes `./package.json` and everything under
+`./static/`. Both are part of the consumer contract. Other files ship with the
+package but are not importable.
 
 ## 3. Load the foundations
 
@@ -311,22 +343,27 @@ footer. Promote a rule into the package only after it represents the same compon
 in at least two applications.
 
 All shared custom properties use the `--sqlfluff-` prefix and shared classes use
-`sqlfluff-`. Treat the vendored directory as read-only.
+`sqlfluff-`. Treat the installed package as read-only.
 
 ## 7. Update the pinned design
 
-Update the submodule deliberately, review the package diff, and commit only the new
-gitlink in the consumer:
+Advance the pin deliberately and review the package diff. Change the commit in the
+dependency specifier and refresh the lockfile:
 
 ```sh
-git -C vendor/sqlfluff.com fetch origin
-git -C vendor/sqlfluff.com checkout <reviewed-commit-or-design-tag>
-git add vendor/sqlfluff.com
+# after editing the pinned commit in package.json
+pnpm install
 ```
 
-Run `design:sync`, the consumer build, and visual checks before merging. This keeps
-historical deployments reproducible and lets each application adopt changes on its
-own schedule.
+Then run `design:sync`, the consumer build, and visual checks before merging. This
+keeps historical deployments reproducible and lets each application adopt changes
+on its own schedule.
+
+Compare what actually changed in the package between two pins:
+
+```sh
+git -c core.pager=cat diff <old-commit> <new-commit> -- packages/design
+```
 
 ## Verification checklist
 

--- a/packages/design/README.md
+++ b/packages/design/README.md
@@ -2,8 +2,8 @@
 
 This internal package is the framework-neutral source of SQLFluff's shared web
 styles, assets, and browser behaviour. It is consumed directly by this Hugo site
-and is intended to be vendored into the documentation and statistics repositories
-through a pinned Git submodule.
+and by the documentation and statistics repositories, which depend on it from Git
+at a pinned commit.
 
 ## Package contents
 
@@ -35,12 +35,12 @@ need the same visual component or behaviour.
 
 ## Integration
 
-See [INTEGRATION.md](INTEGRATION.md) for the submodule workflow, asset load order,
+See [INTEGRATION.md](INTEGRATION.md) for the dependency workflow, asset load order,
 HTML contracts, theme cookie, adapter guidance, and verification checklist.
 
 Repository commits, and optional `design-v*` tags once introduced, version the
-package. Consumers advance their pinned submodule commit through an ordinary pull
-request; no package registry or runtime dependency on `sqlfluff.com` is required.
+package. Consumers advance their pinned commit through an ordinary pull request;
+no package registry or runtime dependency on `sqlfluff.com` is required.
 
 ## Licensing
 

--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -2,5 +2,15 @@
   "name": "@sqlfluff/design",
   "version": "0.1.0",
   "private": true,
-  "description": "Shared visual foundations for SQLFluff web properties"
+  "description": "Shared visual foundations for SQLFluff web properties",
+  "exports": {
+    "./package.json": "./package.json",
+    "./static/*": "./static/*"
+  },
+  "files": [
+    "static",
+    "INTEGRATION.md",
+    "README.md",
+    "THIRD_PARTY_NOTICES.md"
+  ]
 }


### PR DESCRIPTION
## Summary

Lets a Node consumer depend on `@sqlfluff/design` directly from Git at a pinned commit, instead of vendoring this repository as a submodule.

The submodule route works, but it puts a manual `git submodule update --init` between a fresh clone and a working build, requires `submodules: true` in every CI workflow that builds docs, and was raised as a maintenance concern while reviewing the documentation integration. Git dependencies remove all three: `pnpm install` is sufficient, and the lockfile records the resolved commit.

- Add an `exports` map covering `./static/*` and `./package.json`.
- Add `files` so the installed package carries only the assets and its documentation.
- Rewrite the integration guide's source, asset-copy, and update sections around the dependency workflow, keeping the submodule as a documented fallback.
- Update the README and design plan to match.

No change to the asset layout, load order, HTML contracts, tokens, or behaviour. This Hugo site keeps consuming the package through `staticDir` exactly as before.

## The subdirectory constraint

This repository has no root `package.json` and the package sits in `packages/design`, so the specifier needs pnpm's subdirectory suffix:

```jsonc
"@sqlfluff/design": "github:sqlfluff/sqlfluff.com#<commit>&path:/packages/design"
```

Two things worth knowing, both verified rather than assumed:

- **npm and Yarn do not support this.** npm clones the repository, looks for `package.json` at the root, and fails with `ENOENT`. Only pnpm 9 and later resolve it — pnpm 8 fails with an opaque `resolveGit` stack. The guide now says a consumer on this route should declare `"engines": { "pnpm": ">=9" }`, which pnpm enforces by default with a clear `ERR_PNPM_UNSUPPORTED_ENGINE`.
- **Without the suffix the whole Hugo site installs** as an unnamed `sqlfluff.com@0.0.0` package. The guide calls that out so nobody discovers it by accident.

If we later want npm and Yarn compatibility, the options are a root `package.json` with a `files` field, or extracting the package to its own repository. Both work; neither is needed for the documentation site, which is already pnpm-only.

## Why `./package.json` is exported

Consumers locate the asset directory by resolving the manifest rather than hardcoding a path, so the step survives a hoisted or symlinked store:

```js
const manifest = createRequire(import.meta.url).resolve('@sqlfluff/design/package.json')
const assets = resolve(dirname(manifest), 'static/sqlfluff-design')
```

Adding an `exports` map without `"./package.json"` would break exactly that with `ERR_PACKAGE_PATH_NOT_EXPORTED`. Exporting it deliberately makes the pattern safe, and the guide documents both entries as the consumer contract.

## Validation

- Hugo builds clean with the new `package.json` fields; shared assets still emitted under `/sqlfluff-design/`.
- Installed the package from Git with pnpm 9, 10, and 11 and confirmed it resolves as `@sqlfluff/design`, with only the package subdirectory present.
- Confirmed `files` filters the install for both pnpm and npm, so the Hugo layouts and config do not land in `node_modules`.
- Confirmed the `exports` map resolves `./package.json`, `theme.js`, and `tokens.css`, and correctly does not expose `INTEGRATION.md` as a module.
- Cold-store install is ~1.9s; codeload has no subdirectory support so the 884K repository tarball is fetched and the subpath extracted.

## Follow-up worth considering

Two commits pinned during the documentation work were orphaned by squash merges with branch deletion, which breaks a consumer's pin. Cutting `design-v*` tags would fix that permanently and make specifiers readable (`#design-v0.1.0&path:/packages/design`) instead of bare SHAs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let Node consumers install `@sqlfluff/design` directly from Git at a pinned commit, removing the submodule requirement. Adds an explicit `exports` map and `files` to ship only assets and expose `./package.json`; docs updated; no change to layout or behavior.

- **Migration**
  - Add the dependency with the subdirectory suffix: `"@sqlfluff/design": "github:sqlfluff/sqlfluff.com#<commit>&path:/packages/design"`.
  - Use `pnpm >= 9` (npm and Yarn don’t support Git subdirectory installs); enforce via `"engines": { "pnpm": ">=9" }`.
  - Resolve the asset path via the manifest: resolve `@sqlfluff/design/package.json`, then `static/sqlfluff-design/` from that directory.
  - Run your `design:sync` before builds and serve assets at `/sqlfluff-design/`. A Git submodule remains a fallback for non-Node setups.

<sup>Written for commit 4d91ee5d163c19f377c6b99410a38f301d0bfb98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff.com/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

