### PR TITLE
Add Contributors link to main nav

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -25,4 +25,5 @@ disableKinds = ['taxonomy', 'term']
   [params.links]
     docs = "https://docs.sqlfluff.com"
     stats = "/stats/"
+    contributors = "/stats/contributors/"
     source = "https://github.com/sqlfluff/sqlfluff"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -20,6 +20,9 @@
         {{ with .Site.Params.links.stats }}
           <a href="{{ . }}">Stats</a>
         {{ end }}
+        {{ with .Site.Params.links.contributors }}
+          <a href="{{ . }}">Contributors</a>
+        {{ end }}
       {{ end }}
       {{ with .Site.Params.links.source }}
         <a href="{{ . }}">GitHub</a>


### PR DESCRIPTION
## Summary
- Adds a "Contributors" link to the global nav, pointing at `/stats/contributors/` (proxied to the stats site's new `/contributors` page — sqlfluff/sqlfluff-datacoves#52)
- Gated behind the existing `showStats` flag, alongside the "Stats" link

## Test plan
- [x] `hugo --gc` builds cleanly and the nav renders both "Stats" and "Contributors" links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Contributors link to the global nav at /stats/contributors/. It appears only when the existing showStats flag is enabled, alongside the Stats link.

<sup>Written for commit 34c92f0002243a0b8e5c43c8533094543247bb67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sqlfluff/sqlfluff.com/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

